### PR TITLE
Schema update: Adding data element definitions

### DIFF
--- a/CDE_schema.rnc
+++ b/CDE_schema.rnc
@@ -4,13 +4,14 @@ start =
   element data_element_set {
     
     ## Each set has a unique identifier of the format "RDES[0-9]+" (e.g., "RDES42") and a textual name.
-    attribute id { text },
-    attribute name { text },
-    (attribute description { text }
-     & attribute url { xsd:anyURI }
+    attribute id { xsd:string { pattern='RDES\d+' } },
+    attribute shortName { xsd:Name }?,
+    element name { text },
+    (attribute url { xsd:anyURI }
+     & element description { text }
      & authors+
      & history+),
-    element elements { data_element+ }+
+    element elements { data_element+ }
   }
 
 ## Each data element or set can have 0 or more individual and/or organizational authors
@@ -19,20 +20,48 @@ data_element =
   
   ## Each data element has a unique identifier of the format "RDE[0-9]+" (e.g., "RDE54") and a textual name.
   element element {
-    attribute id { text },
-    attribute name { text },
-    (element definition {
+    attribute id { xsd:string { pattern='RDE\d+' } },
+    attribute shortName { xsd:Name },
+    element name { text },
+    element definition {
        text >> a:documentation [ "Each CDE must have a definition." ]
-     }
-     & authors?
-     & history?
-     & index_codes?
-     & element instructions { text }?
-     & element version {
-         attribute number { text },
-         attribute date { xsd:date }
-       }
-     & element images { image* }?)
+    },
+    authors?,
+    element version {
+        attribute versionNumber { xsd:positiveInteger },
+        status_attrs,
+        empty
+    },
+    history?,
+    index_codes?,
+    element question { text },
+    (element instructions { text }?
+     & element images { image+ }?),
+    (
+        element integer_values {
+            attribute min { xsd:integer }?,
+            attribute max { xsd:integer >> a:documentation ["Must be greater than the min attribute"] }?,
+            attribute step { xsd:integer >> a:documentation ["Default is 1"] }?,
+            attribute unit { xsd:Name }?
+        } 
+        | element float_values {
+            attribute min { xsd:float },
+            attribute max { xsd:float >> a:documentation ["Must be greater than the min attribute"] },
+            attribute step { xsd:integer },
+            attribute unit { xsd:Name },
+            empty
+        } 
+        | element boolean_values { empty }
+        | element value_set {
+            element value {
+                attribute value { xsd:Name },
+                element name { text },
+                element definition { text }?,
+                element images { image+ }?,
+                index_codes?
+            }+
+        }
+    )
   }
 person =
   element person {
@@ -57,11 +86,11 @@ org =
 index_codes =
   element index_codes {
     element index_code {
-      attribute scheme { text },
-      attribute code { text },
-      attribute display_name { text }?,
-      attribute url { xsd:anyURI }?
-    }*
+      attribute system { xsd:Name },
+      attribute code { xsd:normalizedString },
+      attribute href { xsd:anyURI }?,
+      text >> a:documentation [ "Index code element contains text for display." ]
+    }+
   }
 image =
   element image {
@@ -73,10 +102,12 @@ image =
     & element source { text }?
     & authors?
   }
-history =
-  element event {
+status_attrs = 
     attribute date { xsd:date },
     attribute status {
       "proposed" | "approved" | "published" | "deprecated"
     }
+history =
+  element event {
+    status_attrs
   }*

--- a/CDE_schema.rnc
+++ b/CDE_schema.rnc
@@ -89,7 +89,7 @@ index_codes =
       attribute system { xsd:Name },
       attribute code { xsd:normalizedString },
       attribute href { xsd:anyURI }?,
-      text >> a:documentation [ "Index code element contains text for display." ]
+      attribute display { text }?
     }+
   }
 image =

--- a/CDE_schema.rng
+++ b/CDE_schema.rng
@@ -1,236 +1,323 @@
-<grammar xmlns="http://relaxng.org/ns/structure/1.0" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
-    <start>
-        <element name="data_element_set">
-            <attribute name="id">
-                <a:documentation>Each set has a unique identifier of the format "RDES[0-9]+" (e.g., "RDES42") and a textual name.</a:documentation>
-                <text/>
-            </attribute>
-            <attribute name="name">
-                <text/>
-            </attribute>
-            <interleave>
-                <attribute name="description">
-                    <text/>
-                </attribute>
-                <attribute name="url">
-                    <data type="anyURI"/>
-                </attribute>
-                <oneOrMore>
-                    <ref name="authors"></ref>
-                </oneOrMore>
-                <oneOrMore>
-                    <ref name="history"></ref>
-                </oneOrMore>
-            </interleave>
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <element name="data_element_set">
+      <attribute name="id">
+        <a:documentation>Each set has a unique identifier of the format "RDES[0-9]+" (e.g., "RDES42") and a textual name.</a:documentation>
+        <data type="string">
+          <param name="pattern">RDES\d+</param>
+        </data>
+      </attribute>
+      <optional>
+        <attribute name="shortName">
+          <data type="Name"/>
+        </attribute>
+      </optional>
+      <element name="name">
+        <text/>
+      </element>
+      <interleave>
+        <attribute name="url">
+          <data type="anyURI"/>
+        </attribute>
+        <element name="description">
+          <text/>
+        </element>
+        <oneOrMore>
+          <ref name="authors"/>
+        </oneOrMore>
+        <oneOrMore>
+          <ref name="history"/>
+        </oneOrMore>
+      </interleave>
+      <element name="elements">
+        <oneOrMore>
+          <ref name="data_element"/>
+        </oneOrMore>
+      </element>
+    </element>
+  </start>
+  <define name="authors">
+    <a:documentation>Each data element or set can have 0 or more individual and/or organizational authors</a:documentation>
+    <zeroOrMore>
+      <ref name="person"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="org"/>
+    </zeroOrMore>
+  </define>
+  <define name="data_element">
+    <element name="element">
+      <a:documentation>Each data element has a unique identifier of the format "RDE[0-9]+" (e.g., "RDE54") and a textual name.</a:documentation>
+      <attribute name="id">
+        <data type="string">
+          <param name="pattern">RDE\d+</param>
+        </data>
+      </attribute>
+      <attribute name="shortName">
+        <data type="Name"/>
+      </attribute>
+      <element name="name">
+        <text/>
+      </element>
+      <element name="definition">
+        <text/>
+        <a:documentation>Each CDE must have a definition.</a:documentation>
+      </element>
+      <optional>
+        <ref name="authors"/>
+      </optional>
+      <element name="version">
+        <attribute name="versionNumber">
+          <data type="positiveInteger"/>
+        </attribute>
+        <ref name="status_attrs"/>
+        <empty/>
+      </element>
+      <optional>
+        <ref name="history"/>
+      </optional>
+      <optional>
+        <ref name="index_codes"/>
+      </optional>
+      <element name="question">
+        <text/>
+      </element>
+      <interleave>
+        <optional>
+          <element name="instructions">
+            <text/>
+          </element>
+        </optional>
+        <optional>
+          <element name="images">
             <oneOrMore>
-                <element name="elements">
-                    <oneOrMore>
-                        <ref name="data_element"></ref>
-                    </oneOrMore>
-                </element>
+              <ref name="image"/>
             </oneOrMore>
+          </element>
+        </optional>
+      </interleave>
+      <choice>
+        <element name="integer_values">
+          <optional>
+            <attribute name="min">
+              <data type="integer"/>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="max">
+              <data type="integer"/>
+              <a:documentation>Must be greater than the min attribute</a:documentation>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="step">
+              <data type="integer"/>
+              <a:documentation>Default is 1</a:documentation>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="unit">
+              <data type="Name"/>
+            </attribute>
+          </optional>
         </element>
-    </start>
-    <define name="authors">
-        <a:documentation>Each data element or set can have 0 or more individual and/or organizational authors</a:documentation>
-        <zeroOrMore>
-            <ref name="person"/>
-        </zeroOrMore>
-        <zeroOrMore>
-            <ref name="org"/>
-        </zeroOrMore>
-    </define>
-    <define name="data_element">
-        <element name="element">
-            <a:documentation>Each data element has a unique identifier of the format "RDE[0-9]+" (e.g., "RDE54") and a textual name.</a:documentation>
-            <attribute name="id">
+        <element name="float_values">
+          <attribute name="min">
+            <data type="float"/>
+          </attribute>
+          <attribute name="max">
+            <data type="float"/>
+            <a:documentation>Must be greater than the min attribute</a:documentation>
+          </attribute>
+          <attribute name="step">
+            <data type="integer"/>
+          </attribute>
+          <attribute name="unit">
+            <data type="Name"/>
+          </attribute>
+          <empty/>
+        </element>
+        <element name="boolean_values">
+          <empty/>
+        </element>
+        <element name="value_set">
+          <oneOrMore>
+            <element name="value">
+              <attribute name="value">
+                <data type="Name"/>
+              </attribute>
+              <element name="name">
                 <text/>
-            </attribute>
-            <attribute name="name">
-                <text/>
-            </attribute>
-            <interleave>
+              </element>
+              <optional>
                 <element name="definition">
-                    <text/>
-                    <a:documentation>Each CDE must have a definition.</a:documentation>
+                  <text/>
                 </element>
-                <optional>
-                    <ref name="authors"></ref>
-                </optional>
-                <optional>
-                    <ref name="history"></ref>
-                </optional>
-                <optional>
-                    <ref name="index_codes"/>
-                </optional>
-                <optional>
-                    <element name="instructions">
-                        <text/>
-                    </element>
-                </optional>
-                <element name="version">
-                    <attribute name="number">
-                        <text/>
-                    </attribute>
-                    <attribute name="date">
-                        <data type="date"/>
-                    </attribute>
+              </optional>
+              <optional>
+                <element name="images">
+                  <oneOrMore>
+                    <ref name="image"/>
+                  </oneOrMore>
                 </element>
-                <optional>
-                    <element name="images">
-                        <zeroOrMore>
-                            <ref name="image"/>
-                        </zeroOrMore>
-                    </element>
-                </optional>
-            </interleave>
-        </element>
-    </define>
-    <define name="person">
-        <element name="person">
-            <element name="name">
-                <text/>
+              </optional>
+              <optional>
+                <ref name="index_codes"/>
+              </optional>
             </element>
-            <interleave>
-                <optional>
-                    <element name="orcid_id">
-                        <text/>
-                    </element>
-                </optional>
-                <zeroOrMore>
-                    <element name="twitter_handle">
-                        <text/>
-                    </element>
-                </zeroOrMore>
-                <zeroOrMore>
-                    <element name="url">
-                        <text/>
-                    </element>
-                </zeroOrMore>
-                <zeroOrMore>
-                    <element name="role">
-                        <choice>
-                            <value>author</value>
-                            <value>editor</value>
-                            <value>translator</value>
-                            <value>reviewer</value>
-                            <value>contributor</value>
-                        </choice>
-                    </element>
-                </zeroOrMore>
-            </interleave>
+          </oneOrMore>
         </element>
-    </define>
-    <define name="org">
-        <element name="organization">
-            <interleave>
-                <element name="name">
-                    <text/>
-                </element>
-                <optional>
-                    <element name="abbreviation">
-                        <text/>
-                    </element>
-                </optional>
-                <optional>
-                    <element name="url">
-                        <data type="anyURI"/>
-                    </element>
-                </optional>
-                <optional>
-                    <element name="comment">
-                        <text/>
-                    </element>
-                </optional>
-                <zeroOrMore>
-                    <element name="role">
-                        <choice>
-                            <value>contributor</value>
-                            <value>sponsor</value>
-                            <value>translator</value>
-                            <value>reviewer</value>
-                            <value>author</value>
-                        </choice>
-                    </element>
-                </zeroOrMore>
-            </interleave>
-        </element>
-    </define>
-    <define name="index_codes">
-        <element name="index_codes">
-            <zeroOrMore>
-                <element name="index_code">
-                    <attribute name="scheme">
-                        <text/>
-                    </attribute>
-                    <attribute name="code">
-                        <text/>
-                    </attribute>
-                    <optional>
-                        <attribute name="display_name">
-                            <text/>
-                        </attribute>
-                    </optional>
-                    <optional>
-                        <attribute name="url">
-                            <data type="anyURI"/>
-                        </attribute>
-                    </optional>
-                </element>
-            </zeroOrMore>
-        </element>
-    </define>
-    <define name="image">
-        <element name="image">
-            <interleave>
-                <attribute name="url">
-                    <data type="anyURI"/>
-                </attribute>
-                <optional>
-                    <attribute name="height">
-                        <data type="positiveInteger"/>
-                    </attribute>
-                </optional>
-                <optional>
-                    <attribute name="width">
-                        <data type="positiveInteger"/>
-                    </attribute>
-                </optional>
-                <optional>
-                    <element name="caption">
-                        <text/>
-                    </element>
-                </optional>
-                <optional>
-                    <element name="rights">
-                        <text/>
-                    </element>
-                </optional>
-                <optional>
-                    <element name="source">
-                        <text/>
-                    </element>
-                </optional>
-                <optional><ref name="authors"></ref>
-                </optional>
-            </interleave>
-        </element>
-    </define>
-    <define name="history">
+      </choice>
+    </element>
+  </define>
+  <define name="person">
+    <element name="person">
+      <element name="name">
+        <text/>
+      </element>
+      <interleave>
+        <optional>
+          <element name="orcid_id">
+            <text/>
+          </element>
+        </optional>
         <zeroOrMore>
-            <element name="event">
-                <attribute name="date">
-                    <data type="date"/>
-                </attribute>
-                <attribute name="status">
-                    <choice>
-                        <value>proposed</value>
-                        <value>approved</value>
-                        <value>published</value>
-                        <value>deprecated</value>
-                    </choice>
-                </attribute>
-            </element>
+          <element name="twitter_handle">
+            <text/>
+          </element>
         </zeroOrMore>
-    </define>
+        <zeroOrMore>
+          <element name="url">
+            <text/>
+          </element>
+        </zeroOrMore>
+        <zeroOrMore>
+          <element name="role">
+            <choice>
+              <value>author</value>
+              <value>editor</value>
+              <value>translator</value>
+              <value>reviewer</value>
+              <value>contributor</value>
+            </choice>
+          </element>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="org">
+    <element name="organization">
+      <interleave>
+        <element name="name">
+          <text/>
+        </element>
+        <optional>
+          <element name="abbreviation">
+            <text/>
+          </element>
+        </optional>
+        <optional>
+          <element name="url">
+            <data type="anyURI"/>
+          </element>
+        </optional>
+        <optional>
+          <element name="comment">
+            <text/>
+          </element>
+        </optional>
+        <zeroOrMore>
+          <element name="role">
+            <choice>
+              <value>contributor</value>
+              <value>sponsor</value>
+              <value>translator</value>
+              <value>reviewer</value>
+              <value>author</value>
+            </choice>
+          </element>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <define name="index_codes">
+    <element name="index_codes">
+      <oneOrMore>
+        <element name="index_code">
+          <attribute name="system">
+            <data type="Name"/>
+          </attribute>
+          <attribute name="code">
+            <data type="normalizedString"/>
+          </attribute>
+          <optional>
+            <attribute name="href">
+              <data type="anyURI"/>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="display"/>
+          </optional>
+        </element>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="image">
+    <element name="image">
+      <interleave>
+        <attribute name="url">
+          <data type="anyURI"/>
+        </attribute>
+        <optional>
+          <attribute name="height">
+            <data type="positiveInteger"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="width">
+            <data type="positiveInteger"/>
+          </attribute>
+        </optional>
+        <optional>
+          <element name="caption">
+            <text/>
+          </element>
+        </optional>
+        <optional>
+          <element name="rights">
+            <text/>
+          </element>
+        </optional>
+        <optional>
+          <element name="source">
+            <text/>
+          </element>
+        </optional>
+        <optional>
+          <ref name="authors"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <define name="status_attrs">
+    <attribute name="date">
+      <data type="date"/>
+    </attribute>
+    <attribute name="status">
+      <choice>
+        <value>proposed</value>
+        <value>approved</value>
+        <value>published</value>
+        <value>deprecated</value>
+      </choice>
+    </attribute>
+  </define>
+  <define name="history">
+    <zeroOrMore>
+      <element name="event">
+        <ref name="status_attrs"/>
+      </element>
+    </zeroOrMore>
+  </define>
 </grammar>

--- a/CDE_schema.xsd
+++ b/CDE_schema.xsd
@@ -3,25 +3,33 @@
   <xs:element name="data_element_set">
     <xs:complexType>
       <xs:sequence>
+        <xs:element ref="name"/>
         <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="description"/>
           <xs:choice>
             <xs:element ref="person"/>
             <xs:element ref="organization"/>
           </xs:choice>
           <xs:group ref="history"/>
         </xs:choice>
-        <xs:element maxOccurs="unbounded" ref="elements"/>
+        <xs:element ref="elements"/>
       </xs:sequence>
       <xs:attribute name="id" use="required">
         <xs:annotation>
           <xs:documentation>Each set has a unique identifier of the format "RDES[0-9]+" (e.g., "RDES42") and a textual name.</xs:documentation>
         </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="RDES\d+"/>
+          </xs:restriction>
+        </xs:simpleType>
       </xs:attribute>
-      <xs:attribute name="name" use="required"/>
-      <xs:attribute name="description" use="required"/>
+      <xs:attribute name="shortName" type="xs:Name"/>
       <xs:attribute name="url" use="required" type="xs:anyURI"/>
     </xs:complexType>
   </xs:element>
+  <xs:element name="name" type="xs:string"/>
+  <xs:element name="description" type="xs:string"/>
   <xs:element name="elements">
     <xs:complexType>
       <xs:sequence>
@@ -43,35 +51,86 @@
       <xs:documentation>Each data element has a unique identifier of the format "RDE[0-9]+" (e.g., "RDE54") and a textual name.</xs:documentation>
     </xs:annotation>
     <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:sequence>
+        <xs:element ref="name"/>
         <xs:element ref="definition"/>
-        <xs:choice>
-          <xs:element ref="person"/>
-          <xs:element ref="organization"/>
-        </xs:choice>
-        <xs:group ref="history"/>
-        <xs:element ref="index_codes"/>
-        <xs:element ref="instructions"/>
+        <xs:group minOccurs="0" ref="authors"/>
         <xs:element ref="version"/>
-        <xs:element ref="images"/>
-      </xs:choice>
-      <xs:attribute name="id" use="required"/>
-      <xs:attribute name="name" use="required"/>
+        <xs:group minOccurs="0" ref="history"/>
+        <xs:element minOccurs="0" ref="index_codes"/>
+        <xs:element ref="question"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="instructions"/>
+          <xs:element ref="images"/>
+        </xs:choice>
+        <xs:choice>
+          <xs:element ref="integer_values"/>
+          <xs:element ref="float_values"/>
+          <xs:element ref="boolean_values"/>
+          <xs:element ref="value_set"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="RDE\d+"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="shortName" use="required" type="xs:Name"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="definition" type="xs:string"/>
-  <xs:element name="instructions" type="xs:string"/>
   <xs:element name="version">
     <xs:complexType>
-      <xs:attribute name="number" use="required"/>
-      <xs:attribute name="date" use="required" type="xs:date"/>
+      <xs:attribute name="versionNumber" use="required" type="xs:positiveInteger"/>
+      <xs:attributeGroup ref="status_attrs"/>
     </xs:complexType>
   </xs:element>
+  <xs:element name="question" type="xs:string"/>
+  <xs:element name="instructions" type="xs:string"/>
   <xs:element name="images">
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="image"/>
+        <xs:element maxOccurs="unbounded" ref="image"/>
       </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="integer_values">
+    <xs:complexType>
+      <xs:attribute name="min" type="xs:integer"/>
+      <xs:attribute name="max" type="xs:integer"/>
+      <xs:attribute name="step" type="xs:integer"/>
+      <xs:attribute name="unit" type="xs:Name"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="float_values">
+    <xs:complexType>
+      <xs:attribute name="min" use="required" type="xs:float"/>
+      <xs:attribute name="max" use="required" type="xs:float"/>
+      <xs:attribute name="step" use="required" type="xs:integer"/>
+      <xs:attribute name="unit" use="required" type="xs:Name"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="boolean_values">
+    <xs:complexType/>
+  </xs:element>
+  <xs:element name="value_set">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="value"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="value">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="name"/>
+        <xs:element minOccurs="0" ref="definition"/>
+        <xs:element minOccurs="0" ref="images"/>
+        <xs:element minOccurs="0" ref="index_codes"/>
+      </xs:sequence>
+      <xs:attribute name="value" use="required" type="xs:Name"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="person">
@@ -97,7 +156,6 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  <xs:element name="name" type="xs:string"/>
   <xs:element name="orcid_id" type="xs:string"/>
   <xs:element name="twitter_handle" type="xs:string"/>
   <xs:element name="organization">
@@ -126,16 +184,16 @@
   <xs:element name="index_codes">
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="index_code"/>
+        <xs:element maxOccurs="unbounded" ref="index_code"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="index_code">
     <xs:complexType>
-      <xs:attribute name="scheme" use="required"/>
-      <xs:attribute name="code" use="required"/>
-      <xs:attribute name="display_name"/>
-      <xs:attribute name="url" type="xs:anyURI"/>
+      <xs:attribute name="system" use="required" type="xs:Name"/>
+      <xs:attribute name="code" use="required" type="xs:normalizedString"/>
+      <xs:attribute name="href" type="xs:anyURI"/>
+      <xs:attribute name="display"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="image">
@@ -157,6 +215,19 @@
   <xs:element name="caption" type="xs:string"/>
   <xs:element name="rights" type="xs:string"/>
   <xs:element name="source" type="xs:string"/>
+  <xs:attributeGroup name="status_attrs">
+    <xs:attribute name="date" use="required" type="xs:date"/>
+    <xs:attribute name="status" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="proposed"/>
+          <xs:enumeration value="approved"/>
+          <xs:enumeration value="published"/>
+          <xs:enumeration value="deprecated"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
   <xs:group name="history">
     <xs:sequence>
       <xs:element minOccurs="0" maxOccurs="unbounded" ref="event"/>
@@ -164,17 +235,7 @@
   </xs:group>
   <xs:element name="event">
     <xs:complexType>
-      <xs:attribute name="date" use="required" type="xs:date"/>
-      <xs:attribute name="status" use="required">
-        <xs:simpleType>
-          <xs:restriction base="xs:token">
-            <xs:enumeration value="proposed"/>
-            <xs:enumeration value="approved"/>
-            <xs:enumeration value="published"/>
-            <xs:enumeration value="deprecated"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
+      <xs:attributeGroup ref="status_attrs"/>
     </xs:complexType>
   </xs:element>
 </xs:schema>

--- a/SampleDES.xml
+++ b/SampleDES.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="CDE_schema.rnc" type="application/relax-ng-compact-syntax"?>
+<data_element_set id="RDES3" shortName="adrenalNodule" url="http://radelement.org/api/v1/projects/3">
+    <name>CAR/DS Adrenal Nodule</name>
+    <description>ACR Assist project for describing adrenal nodules.</description>
+    <elements>
+        <element id="RDE41" shortName="noduleSize">
+            <name>Nodule size</name>
+            <definition>The greatest linear dimension of the adrenal nodule.</definition>
+            <version date="2015-07-05" status="proposed" versionNumber="1"/>
+            <index_codes>
+                <index_code system="SNOMEDCT" code="246120007" href="http://radelement.org/api/v1/codes/SNOMEDCT/246120007">nodule size</index_code>
+            </index_codes>
+            <question>Enter the greatest diameter of the adrenal nodule</question>
+            <integer_values min="0" max="999" step="1" unit="mm"/>
+        </element>
+        <element id="RDE42" shortName="side">
+            <name>Side</name>
+            <definition>The side of the body (right or left)</definition>
+            <version versionNumber="1" date="2015-07-05" status="proposed"/>
+            <question>Side</question>
+            <value_set>
+                <value value="R">
+                    <name>Right</name>
+                    <index_codes>
+                        <index_code system="RADLEX" code="RID5825" href="http://radelement.org/api/v1/codes/RADLEX/RID5825">Right</index_code>
+                        <index_code system="SNOMEDCT" code="24028007" href="http://radelement.org/api/v1/codes/SNOMEDCT/24028007">Right</index_code>
+                    </index_codes>
+                </value>
+                <value value="L">
+                    <name>Left</name>
+                    <index_codes>
+                        <index_code system="RADLEX" code="RID5824" href="http://radelement.org/api/v1/codes/RADLEX/RID5824">Left</index_code>
+                        <index_code system="SNOMEDCT" code="7771000" href="http://radelement.org/api/v1/codes/SNOMEDCT/7771000">Left</index_code>
+                    </index_codes>
+                </value>
+            </value_set>
+        </element>
+    </elements>
+</data_element_set>

--- a/SampleDES.xml
+++ b/SampleDES.xml
@@ -9,7 +9,9 @@
             <definition>The greatest linear dimension of the adrenal nodule.</definition>
             <version date="2015-07-05" status="proposed" versionNumber="1"/>
             <index_codes>
-                <index_code system="SNOMEDCT" code="246120007" href="http://radelement.org/api/v1/codes/SNOMEDCT/246120007">nodule size</index_code>
+                <index_code system="SNOMEDCT" code="246120007" href="http://radelement.org/api/v1/codes/SNOMEDCT/246120007">
+                    <display>nodule size</display>
+                </index_code>
             </index_codes>
             <question>Enter the greatest diameter of the adrenal nodule</question>
             <integer_values min="0" max="999" step="1" unit="mm"/>
@@ -23,7 +25,9 @@
                 <value value="R">
                     <name>Right</name>
                     <index_codes>
-                        <index_code system="RADLEX" code="RID5825" href="http://radelement.org/api/v1/codes/RADLEX/RID5825">Right</index_code>
+                        <index_code system="RADLEX" code="RID5825" href="http://radelement.org/api/v1/codes/RADLEX/RID5825">
+                            <display>Right</display>
+                        </index_code>
                         <index_code system="SNOMEDCT" code="24028007" href="http://radelement.org/api/v1/codes/SNOMEDCT/24028007">Right</index_code>
                     </index_codes>
                 </value>

--- a/SampleDES.xml
+++ b/SampleDES.xml
@@ -9,9 +9,7 @@
             <definition>The greatest linear dimension of the adrenal nodule.</definition>
             <version date="2015-07-05" status="proposed" versionNumber="1"/>
             <index_codes>
-                <index_code system="SNOMEDCT" code="246120007" href="http://radelement.org/api/v1/codes/SNOMEDCT/246120007">
-                    <display>nodule size</display>
-                </index_code>
+                <index_code system="SNOMEDCT" code="246120007" href="http://radelement.org/api/v1/codes/SNOMEDCT/246120007" display="nodule size"/>                
             </index_codes>
             <question>Enter the greatest diameter of the adrenal nodule</question>
             <integer_values min="0" max="999" step="1" unit="mm"/>
@@ -25,17 +23,15 @@
                 <value value="R">
                     <name>Right</name>
                     <index_codes>
-                        <index_code system="RADLEX" code="RID5825" href="http://radelement.org/api/v1/codes/RADLEX/RID5825">
-                            <display>Right</display>
-                        </index_code>
-                        <index_code system="SNOMEDCT" code="24028007" href="http://radelement.org/api/v1/codes/SNOMEDCT/24028007">Right</index_code>
+                        <index_code system="RADLEX" code="RID5825" href="http://radelement.org/api/v1/codes/RADLEX/RID5825" display="Right"/>
+                        <index_code system="SNOMEDCT" code="24028007" href="http://radelement.org/api/v1/codes/SNOMEDCT/24028007" display="Right"/>
                     </index_codes>
                 </value>
                 <value value="L">
                     <name>Left</name>
                     <index_codes>
-                        <index_code system="RADLEX" code="RID5824" href="http://radelement.org/api/v1/codes/RADLEX/RID5824">Left</index_code>
-                        <index_code system="SNOMEDCT" code="7771000" href="http://radelement.org/api/v1/codes/SNOMEDCT/7771000">Left</index_code>
+                        <index_code system="RADLEX" code="RID5824" href="http://radelement.org/api/v1/codes/RADLEX/RID5824" display="Left"/>
+                        <index_code system="SNOMEDCT" code="7771000" href="http://radelement.org/api/v1/codes/SNOMEDCT/7771000" display="Left"/>
                     </index_codes>
                 </value>
             </value_set>


### PR DESCRIPTION
Proposing adding more detail about the definition of data elements into the definition of a data element set.

Included a sample XML file which validates that demonstrates what this might look like for a subset of the adrenal nodule data element set.

Also tweaked the schema definition to be more specific about what's expected in the different attribute types.